### PR TITLE
Fix wrong module name in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,13 +72,13 @@ commandline:
 
 .. code:: bash
 
-  $ python -m pj source.py
+  $ python -m metapensiero.pj source.py
 
 or:
 
 .. code:: bash
 
-  $ python -m pj -5 source.py
+  $ python -m metapensiero.pj -5 source.py
 
 to transpile.
 


### PR DESCRIPTION
The README instructs to launch `python -m pj`, while the module installs in `.virtualenv/three/lib/python3.4/site-packages/metapensiero/pj/`, and therefore has to be launched with `python -m metapensiero.pj`.