### PR TITLE
Extend try...except translation support

### DIFF
--- a/src/metapensiero/pj/transformations/classes.py
+++ b/src/metapensiero/pj/transformations/classes.py
@@ -359,6 +359,29 @@ def Subscript_super(t, x):
                 result = JSSubscript(JSSuper(), _normalize_name(sup_method))
             return result
 
+def _build_call_isinstance(tgt, cls_or_seq):
+    if isinstance(cls_or_seq, (ast.Tuple, ast.List, ast.Set)):
+        classes = cls_or_seq.elts
+        args = tuple((tgt, c) for c in classes)
+        return JSMultipleArgsOp(JSOpInstanceof(), JSOpOr(), *args)
+    else:
+        cls = cls_or_seq
+        if isinstance(cls, ast.Name) and cls.id == 'str':
+            return JSMultipleArgsOp(
+                (JSOpStrongEq(), JSOpInstanceof()),
+                JSOpOr(),
+                (JSUnaryOp(JSOpTypeof(), tgt), JSStr('string')),
+                (tgt, JSName('String'))
+            )
+        elif isinstance(cls, ast.Name) and cls.id in ['int', 'float']:
+            return JSMultipleArgsOp(
+                (JSOpStrongEq(), JSOpInstanceof()),
+                JSOpOr(),
+                (JSUnaryOp(JSOpTypeof(), tgt), JSStr('number')),
+                (tgt, JSName('Number'))
+            )
+        else:
+            return JSBinOp(tgt, JSOpInstanceof(), cls)
 
 def Call_isinstance(t, x):
     """Translate ``isinstance(foo, Bar)`` to ``foo instanceof Bar`` and
@@ -381,31 +404,7 @@ def Call_isinstance(t, x):
     """
     if (isinstance(x.func, ast.Name) and x.func.id == 'isinstance'):
         assert len(x.args) == 2
-        if isinstance(x.args[1], (ast.Tuple, ast.List, ast.Set)):
-            classes = x.args[1].elts
-            target = x.args[0]
-            args = tuple((target, c) for c in classes)
-            return JSMultipleArgsOp(JSOpInstanceof(), JSOpOr(), *args)
-        else:
-            tgt = x.args[0]
-            cls = x.args[1]
-            if isinstance(cls, ast.Name) and cls.id == 'str':
-                return JSMultipleArgsOp(
-                    (JSOpStrongEq(), JSOpInstanceof()),
-                    JSOpOr(),
-                    (JSUnaryOp(JSOpTypeof(), tgt), JSStr('string')),
-                    (tgt, JSName('String'))
-                )
-            elif isinstance(cls, ast.Name) and cls.id in ['int', 'float']:
-                return JSMultipleArgsOp(
-                    (JSOpStrongEq(), JSOpInstanceof()),
-                    JSOpOr(),
-                    (JSUnaryOp(JSOpTypeof(), tgt), JSStr('number')),
-                    (tgt, JSName('Number'))
-                )
-            else:
-                return JSBinOp(tgt, JSOpInstanceof(), cls)
-
+        return _build_call_isinstance(x.args[0], x.args[1])
 
 def Call_issubclass(t, x):
     """Translate ``issubclass(Foo, Bar)`` to ``Foo.prototype instanceof Bar``.

--- a/src/metapensiero/pj/transformations/common.py
+++ b/src/metapensiero/pj/transformations/common.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# :Project:  metapensiero.pj -- common transformation functions
+# :Authors:  Andrew Schaaf <andrew@andrewschaaf.com>,
+#            Alberto Berti <alberto@metapensiero.it>
+#            Devan Lai <devan.lai@gmail.com>
+# :License:  GNU General Public License version 3 or later
+#
+
+import ast
+from ..js_ast import (
+    JSBinOp,
+    JSMultipleArgsOp,
+    JSName,
+    JSOpInstanceof,
+    JSOpOr,
+    JSOpStrongEq,
+    JSOpTypeof,
+    JSStr,
+    JSUnaryOp,
+)
+
+
+def _build_call_isinstance(tgt, cls_or_seq):
+    """Helper to build the translate the equivalence of ``isinstance(foo, Bar)``
+    to ``foo instanceof Bar`` and ``isinstance(Foo, (Bar, Zoo))`` to
+    ``foo instanceof Bar || foo instanceof Zoo``.
+    """
+    if isinstance(cls_or_seq, (ast.Tuple, ast.List, ast.Set)):
+        classes = cls_or_seq.elts
+        args = tuple((tgt, c) for c in classes)
+        return JSMultipleArgsOp(JSOpInstanceof(), JSOpOr(), *args)
+    else:
+        cls = cls_or_seq
+        if isinstance(cls, ast.Name) and cls.id == 'str':
+            return JSMultipleArgsOp(
+                (JSOpStrongEq(), JSOpInstanceof()),
+                JSOpOr(),
+                (JSUnaryOp(JSOpTypeof(), tgt), JSStr('string')),
+                (tgt, JSName('String'))
+            )
+        elif isinstance(cls, ast.Name) and cls.id in ['int', 'float']:
+            return JSMultipleArgsOp(
+                (JSOpStrongEq(), JSOpInstanceof()),
+                JSOpOr(),
+                (JSUnaryOp(JSOpTypeof(), tgt), JSStr('number')),
+                (tgt, JSName('Number'))
+            )
+        else:
+            return JSBinOp(tgt, JSOpInstanceof(), cls)

--- a/src/metapensiero/pj/transformations/exceptions.py
+++ b/src/metapensiero/pj/transformations/exceptions.py
@@ -11,16 +11,16 @@ import ast
 from ..js_ast import (
     JSBinOp,
     JSIfStatement,
-    JSLetStatement,
     JSName,
     JSNewCall,
     JSOpInstanceof,
     JSStatements,
     JSThrowStatement,
     JSTryCatchFinallyStatement,
+    JSVarStatement,
 )
 
-from .classes import _build_call_isinstance
+from .common import _build_call_isinstance
 
 
 def Try(t, x):
@@ -47,7 +47,7 @@ def Try(t, x):
             body = h.body
             if h.name is not None and h.name != ename:
                 # Rename the exception to match the handler
-                rename = JSLetStatement([h.name],[ename])
+                rename = JSVarStatement([h.name], [ename])
                 body = [rename] + h.body
 
             # if it's  the last except and it's a catchall

--- a/tests/test_various/test_translate_object/try_except_complex.js
+++ b/tests/test_various/test_translate_object/try_except_complex.js
@@ -42,11 +42,11 @@ try {
     value += 1;
 } catch(e) {
     if ((e instanceof MySecondError)) {
-        let err = e;
+        var err = e;
         value += 20;
     } else {
         if (((e instanceof MyThirdError) || (e instanceof MyFourthError))) {
-            let err2 = e;
+            var err2 = e;
             value += 30;
         } else {
             if ((e instanceof MyError)) {

--- a/tests/test_various/test_translate_object/try_except_complex.js
+++ b/tests/test_various/test_translate_object/try_except_complex.js
@@ -14,18 +14,46 @@ MyError.prototype.constructor = MyError;
 class MySecondError extends MyError {
     /* A stupid error */
 }
+function MyThirdError(message) {
+    this.name = "MyThirdError";
+    this.message = (message || "Custom error MyThirdError");
+    if (((typeof Error.captureStackTrace) === "function")) {
+        Error.captureStackTrace(this, this.constructor);
+    } else {
+        this.stack = new Error(message).stack;
+    }
+}
+MyThirdError.prototype = Object.create(Error.prototype);
+MyThirdError.prototype.constructor = MyThirdError;
+function MyFourthError(message) {
+    this.name = "MyFourthError";
+    this.message = (message || "Custom error MyFourthError");
+    if (((typeof Error.captureStackTrace) === "function")) {
+        Error.captureStackTrace(this, this.constructor);
+    } else {
+        this.stack = new Error(message).stack;
+    }
+}
+MyFourthError.prototype = Object.create(Error.prototype);
+MyFourthError.prototype.constructor = MyFourthError;
 try {
     value += 1;
     throw new MyError("Something bad happened");
     value += 1;
 } catch(e) {
     if ((e instanceof MySecondError)) {
+        let err = e;
         value += 20;
     } else {
-        if ((e instanceof MyError)) {
+        if (((e instanceof MyThirdError) || (e instanceof MyFourthError))) {
+            let err2 = e;
             value += 30;
         } else {
-            value += 40;
+            if ((e instanceof MyError)) {
+                value += 40;
+            } else {
+                value += 50;
+            }
         }
     }
 } finally {

--- a/tests/test_various/test_translate_object/try_except_complex.py
+++ b/tests/test_various/test_translate_object/try_except_complex.py
@@ -10,15 +10,23 @@ def func():
     class MySecondError(MyError):
         """A stupid error"""
 
+    class MyThirdError(Exception):
+        pass
+
+    class MyFourthError(Exception):
+        pass
+
     try:
         value += 1
         raise MyError("Something bad happened")
         value += 1
-    except MySecondError:
+    except MySecondError as err:
         value += 20
-    except MyError:
+    except (MyThirdError, MyFourthError) as err2:
         value += 30
-    except:
+    except MyError:
         value += 40
+    except:
+        value += 50
     finally:
         value += 1


### PR DESCRIPTION
Preliminary pull request to add support for more forms of try...except.
The following forms are now accepted:
Exceptions from other modules:

    try:
        value = struct.unpack("foo")
    except struct.error:
        print("oops")
    ---
    import * as struct from 'struct';
    var value;
    try {
        value = struct.unpack("foo");
    } catch(e) {
        if ((e instanceof struct.error)) {
            console.log("oops");
        } else {
            throw e;
        }
    }

Matching against a sequence of exception types (when known at transpile-time):

    try:
        value = 1/input("enter zero here")
    except (KeyboardInterrupt, ZeroDivisionError):
        print("oops")
    ---
    var value;
    try {
        value = (1 / input("enter zero here"));
    } catch(e) {
        if (((e instanceof KeyboardInterrupt) || (e instanceof ZeroDivisionError))) {
            console.log("oops");
        } else {
            throw e;
        }
    }


Using different variable names in each except clause:

    try:
        1/0
    except ZeroDivisionError as err1:
        print("oops", err1)
    except RuntimeError as err2:
        print("uhoh", err2)
    ---
    try {
        (1 / 0);
    } catch(err2) {
        if ((err2 instanceof ZeroDivisionError)) {
            let err1 = err2;
            console.log("oops", err1);
        } else {
            if ((err2 instanceof RuntimeError)) {
                console.log("uhoh", err2);
            } else {
                throw err2;
            }
        }
    }

Open questions:
To handle sequences of exceptions, I borrowed some of the code from `Call_isinstance` and split it out into a separate function, `_build_call_isinstance`. Do you have any thoughts on where that functionality should live? Right now I'm just directly importing it from the classes module, which is terrible.

Is there a established way to update the expected test output? I could find any way to transpile the code with body_only=True short of calling `translate_object` directly.